### PR TITLE
fix: make backend proxy host configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Access the app at [http://localhost:3000](http://localhost:3000)
 | `PORT` | Application port (default: 3000) | ❌ |
 | `MONGO_URI` | MongoDB connection string | ❌ |
 | `ADMIN_EMAIL/USERNAME/PASSWORD` | Initial admin user | ❌ |
+| `BACKEND_HOST` | Backend hostname for nginx proxy (default: musivault-backend) | ❌ |
+| `BACKEND_PORT` | Backend port for nginx proxy (default: 5000) | ❌ |
 
 Generate a session secret: `openssl rand -base64 32`
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -62,6 +62,9 @@ services:
     restart: unless-stopped
     ports:
       - "${PORT:-3000}:80"
+    environment:
+      - BACKEND_HOST=${BACKEND_HOST:-musivault-backend}
+      - BACKEND_PORT=${BACKEND_PORT:-5000}
     depends_on:
       - backend
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,9 @@ services:
     restart: unless-stopped
     ports:
       - "${PORT:-3000}:80"
+    environment:
+      - BACKEND_HOST=${BACKEND_HOST:-musivault-backend}
+      - BACKEND_PORT=${BACKEND_PORT:-5000}
     depends_on:
       - backend
     networks:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -34,8 +34,12 @@ LABEL version=$VERSION
 LABEL commit=$COMMIT_SHA
 LABEL build_date=$BUILD_DATE
 
-# Copy custom nginx config
-COPY nginx.conf /etc/nginx/nginx.conf
+# Copy nginx config template for runtime substitution
+COPY nginx.conf.template /etc/nginx/nginx.conf.template
+
+# Copy entrypoint script
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 
 # Copy built files from builder
 COPY --from=builder /app/dist /usr/share/nginx/html
@@ -43,5 +47,9 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 # Expose port 80
 EXPOSE 80
 
-# Start nginx
-CMD ["nginx", "-g", "daemon off;"]
+# Environment variables for backend connection (can be overridden)
+ENV BACKEND_HOST=backend
+ENV BACKEND_PORT=5000
+
+# Use entrypoint script to substitute env vars and start nginx
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# Set default values for backend connection
+export BACKEND_HOST=${BACKEND_HOST:-backend}
+export BACKEND_PORT=${BACKEND_PORT:-5000}
+
+echo "Configuring nginx to proxy API requests to ${BACKEND_HOST}:${BACKEND_PORT}"
+
+# Substitute environment variables in nginx config
+# Only substitute BACKEND_HOST and BACKEND_PORT, preserve nginx variables like $uri
+envsubst '${BACKEND_HOST} ${BACKEND_PORT}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+
+# Start nginx
+exec nginx -g 'daemon off;'

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -46,7 +46,7 @@ http {
 
         # API proxy
         location /api {
-            proxy_pass http://backend:5000;
+            proxy_pass http://${BACKEND_HOST}:${BACKEND_PORT};
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
Fixes #10 

## Changes
- Added nginx.conf.template with environment variable placeholders
- Created docker-entrypoint.sh to substitute vars at runtime
- Updated Dockerfile to use envsubst
- Default BACKEND_HOST is now `musivault-backend` (container_name)